### PR TITLE
Remove hibernate and did a bunch of cleanup

### DIFF
--- a/aw_watcher_afk/afk.py
+++ b/aw_watcher_afk/afk.py
@@ -89,8 +89,9 @@ class AFKWatcher:
                 # If becomes AFK
                 elif not self.afk and seconds_since_last_input >= self.settings.timeout:
                     logger.info("Became AFK")
-                    self.afk = True
                     last_input = self.now - timedelta(seconds=seconds_since_last_input)
+                    self.ping(self.afk, timestamp=last_input)
+                    self.afk = True
                     self.ping(self.afk, timestamp=last_input, duration=seconds_since_last_input)
                 # Send a heartbeat if no state change was made
                 else:

--- a/aw_watcher_afk/afk.py
+++ b/aw_watcher_afk/afk.py
@@ -90,7 +90,7 @@ class AFKWatcher:
                 elif not self.afk and seconds_since_last_input >= self.settings.timeout:
                     logger.info("Became AFK")
                     self.afk = True
-                    last_input = self.now - self.timedelta_since_last_input
+                    last_input = self.now - timedelta(seconds=seconds_since_last_input)
                     self.ping(self.afk, timestamp=last_input, duration=seconds_since_last_input)
                 # Send a heartbeat if no state change was made
                 else:

--- a/aw_watcher_afk/afk.py
+++ b/aw_watcher_afk/afk.py
@@ -22,10 +22,8 @@ logger = logging.getLogger(__name__)
 class Settings:
     def __init__(self, config_section):
         self.timeout = config_section.getfloat("timeout")
-        self.update_interval = config_section.getfloat("update_interval")
-        self.check_interval = config_section.getfloat("check_interval")
-        # TODO: This is a better name for whichever variable above is this one
-        self.polling_interval = 1
+        self.update_time = config_section.getfloat("update_time")
+        self.poll_time = config_section.getfloat("poll_time")
 
 
 def get_seconds_since_last_input():
@@ -98,7 +96,7 @@ class AFKWatcher:
                 else:
                     self.ping(self.afk)
 
-                sleep(self.settings.polling_interval)
+                sleep(self.settings.poll_time)
 
             except KeyboardInterrupt:
                 logger.info("afkwatcher stopped by keyboard interrupt")

--- a/aw_watcher_afk/config.py
+++ b/aw_watcher_afk/config.py
@@ -3,13 +3,13 @@ from aw_core.config import load_config
 
 default_settings = {
     "timeout": "180",
-    "update_interval": "30",
-    "check_interval": "5",
+    "update_time": "30",
+    "poll_time": "5",
 }
 default_testing_settings = {
     "timeout": "20",
-    "update_interval": "5",
-    "check_interval": "1",
+    "update_time": "5",
+    "poll_time": "1",
 }
 
 default_config = ConfigParser()


### PR DESCRIPTION
Changes made:

 - Removed hibernation events
 - Removed unnecessary class variables
 - Fixed bug where os.getppid() would cause OSError on non-Unix OS's
 - Renamed configuration options to make consistent with aw-watcher-window
 - Misc cleanup

A major improvement overall.