### PR TITLE
fix: add +1ms to get rid of 20s afk-events not being merged by heartbeat

### DIFF
--- a/aw_watcher_afk/afk.py
+++ b/aw_watcher_afk/afk.py
@@ -106,8 +106,12 @@ class AFKWatcher:
                 # Send a heartbeat if no state change was made
                 else:
                     if afk:
+                        # we need the +1ms here too, to make sure we don't "miss" the last heartbeat
+                        # (if last_input hasn't changed)
                         self.ping(
-                            afk, timestamp=last_input, duration=seconds_since_input
+                            afk,
+                            timestamp=last_input + td1ms,
+                            duration=seconds_since_input,
                         )
                     else:
                         self.ping(afk, timestamp=last_input)


### PR DESCRIPTION
Discovered that whenever I got afk, there was a 20s AFK event, and also a however long AFK event (longer than 20s) starting at the same time. Upon closer inspection they were 1ms off, which this fixes.