### PR TITLE
fix: client.wait_for_start()

### DIFF
--- a/aw_watcher_afk/afk.py
+++ b/aw_watcher_afk/afk.py
@@ -62,7 +62,7 @@ class AFKWatcher:
         logger.info("aw-watcher-afk started")
 
         # Initialization
-        self.client.wait_for_server()
+        self.client.wait_for_start()
 
         eventtype = "afkstatus"
         self.client.create_bucket(self.bucketname, eventtype, queued=True)


### PR DESCRIPTION
wait_for_server -> wait_for_start
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Rename `wait_for_server()` to `wait_for_start()` in `AFKWatcher.run()` in `afk.py`.
> 
>   - **Refactor**:
>     - Rename `self.client.wait_for_server()` to `self.client.wait_for_start()` in `run()` method of `AFKWatcher` class in `afk.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Faw-watcher-afk&utm_source=github&utm_medium=referral)<sup> for d1ef1061777831efe46aec1c5e0be45f1102b3a8. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->