### PR TITLE
feat: Mark as AFK when lock screen is shown

### DIFF
--- a/aw_watcher_afk/afk.py
+++ b/aw_watcher_afk/afk.py
@@ -90,7 +90,7 @@ class AFKWatcher:
                 logger.debug(f"Lock screen shown: {showing_lock_screen}")
 
                 # If no longer AFK
-                if afk and (seconds_since_input < self.settings.timeout or not showing_lock_screen):
+                if afk and seconds_since_input < self.settings.timeout:
                     logger.info("No longer AFK")
                     self.ping(afk, timestamp=last_input)
                     afk = False

--- a/aw_watcher_afk/afk.py
+++ b/aw_watcher_afk/afk.py
@@ -13,13 +13,13 @@ system = platform.system()
 
 if system == "Windows":
     # noreorder
-    from .windows import seconds_since_last_input  # fmt: skip
+    from .windows import seconds_since_last_input, lock_screen_shown  # fmt: skip
 elif system == "Darwin":
     # noreorder
-    from .macos import seconds_since_last_input  # fmt: skip
+    from .macos import seconds_since_last_input, lock_screen_shown  # fmt: skip
 elif system == "Linux":
     # noreorder
-    from .unix import seconds_since_last_input  # fmt: skip
+    from .unix import seconds_since_last_input, lock_screen_shown  # fmt: skip
 else:
     raise Exception(f"Unsupported platform: {system}")
 
@@ -84,18 +84,20 @@ class AFKWatcher:
 
                 now = datetime.now(timezone.utc)
                 seconds_since_input = seconds_since_last_input()
+                showing_lock_screen = lock_screen_shown()
                 last_input = now - timedelta(seconds=seconds_since_input)
                 logger.debug(f"Seconds since last input: {seconds_since_input}")
+                logger.debug(f"Lock screen shown: {showing_lock_screen}")
 
                 # If no longer AFK
-                if afk and seconds_since_input < self.settings.timeout:
+                if afk and (seconds_since_input < self.settings.timeout or not showing_lock_screen):
                     logger.info("No longer AFK")
                     self.ping(afk, timestamp=last_input)
                     afk = False
                     # ping with timestamp+1ms with the next event (to ensure the latest event gets retrieved by get_event)
                     self.ping(afk, timestamp=last_input + td1ms)
                 # If becomes AFK
-                elif not afk and seconds_since_input >= self.settings.timeout:
+                elif not afk and (seconds_since_input >= self.settings.timeout or (showing_lock_screen and seconds_since_input >= 5)):
                     logger.info("Became AFK")
                     self.ping(afk, timestamp=last_input)
                     afk = True

--- a/aw_watcher_afk/macos.py
+++ b/aw_watcher_afk/macos.py
@@ -1,6 +1,14 @@
 from Quartz.CoreGraphics import (CGEventSourceSecondsSinceLastEventType,
                                  kCGEventSourceStateHIDSystemState,
-                                 kCGAnyInputEventType)
+                                 kCGAnyInputEventType,
+                                 CGSessionCopyCurrentDictionary)
+
+
+def lock_screen_shown() -> bool:
+    session = CGSessionCopyCurrentDictionary()
+    if "CGSSessionScreenIsLocked" in session:
+        return session["CGSSessionScreenIsLocked"] == True
+    return False
 
 
 def seconds_since_last_input() -> float:
@@ -11,4 +19,4 @@ if __name__ == "__main__":
     from time import sleep
     while True:
         sleep(1)
-        print(seconds_since_last_input())
+        print(seconds_since_last_input(), lock_screen_shown())

--- a/aw_watcher_afk/unix.py
+++ b/aw_watcher_afk/unix.py
@@ -43,7 +43,12 @@ def seconds_since_last_input():
     return _last_input_unix.seconds_since_last_input()
 
 
+def lock_screen_shown() -> bool:
+    # TODO: Linux implementation
+    return False
+
+
 if __name__ == "__main__":
     while True:
         sleep(1)
-        print(seconds_since_last_input())
+        print(seconds_since_last_input(), lock_screen_shown())

--- a/aw_watcher_afk/windows.py
+++ b/aw_watcher_afk/windows.py
@@ -26,6 +26,11 @@ def _getTickCount() -> int:
     return c_GetTickCount()
 
 
+def lock_screen_shown() -> bool:
+    # TODO: Windows implementation
+    return False
+
+
 def seconds_since_last_input():
     seconds_since_input = (_getTickCount() - _getLastInputTick()) / 1000
     return seconds_since_input
@@ -34,4 +39,4 @@ def seconds_since_last_input():
 if __name__ == "__main__":
     while True:
         time.sleep(1)
-        print(seconds_since_last_input())
+        print(seconds_since_last_input(), lock_screen_shown())


### PR DESCRIPTION
Resolves #66. The user will be marked as AFK if the lock screen is shown and if the user hasn't made inputs for at least 5 seconds. There is currently no configuration option for this amount of time since it seemed unnecessary and this is just a quick check in case the user is doing something on their lock screen.

No changes were made to how the user will be marked as no longer AFK, since the inputs check will already catch them logging back into their machine.

Appears to be working on my macOS machine. I have not added implementations for Windows and Linux.

This PR has not been formatted.