### PR TITLE
fix: auto-recover input listeners after X server restart

### DIFF
--- a/aw_watcher_afk/listeners.py
+++ b/aw_watcher_afk/listeners.py
@@ -41,12 +41,18 @@ class KeyboardListener(EventFactory):
     def __init__(self):
         EventFactory.__init__(self)
         self.logger = logger.getChild("keyboard")
+        self._listener = None
 
     def start(self):
         from pynput import keyboard
 
-        listener = keyboard.Listener(on_press=self.on_press, on_release=self.on_release)
-        listener.start()
+        self._listener = keyboard.Listener(
+            on_press=self.on_press, on_release=self.on_release
+        )
+        self._listener.start()
+
+    def is_alive(self) -> bool:
+        return self._listener is not None and self._listener.is_alive()
 
     def _reset_data(self):
         self.event_data = {"presses": 0}
@@ -67,6 +73,7 @@ class MouseListener(EventFactory):
         EventFactory.__init__(self)
         self.logger = logger.getChild("mouse")
         self.pos = None
+        self._listener = None
 
     def _reset_data(self):
         self.event_data = defaultdict(int)
@@ -77,10 +84,13 @@ class MouseListener(EventFactory):
     def start(self):
         from pynput import mouse
 
-        listener = mouse.Listener(
+        self._listener = mouse.Listener(
             on_move=self.on_move, on_click=self.on_click, on_scroll=self.on_scroll
         )
-        listener.start()
+        self._listener.start()
+
+    def is_alive(self) -> bool:
+        return self._listener is not None and self._listener.is_alive()
 
     def on_move(self, x, y):
         newpos = (x, y)

--- a/aw_watcher_afk/listeners.py
+++ b/aw_watcher_afk/listeners.py
@@ -51,6 +51,10 @@ class KeyboardListener(EventFactory):
         )
         self._listener.start()
 
+    def stop(self):
+        if self._listener is not None:
+            self._listener.stop()
+
     def is_alive(self) -> bool:
         return self._listener is not None and self._listener.is_alive()
 
@@ -88,6 +92,10 @@ class MouseListener(EventFactory):
             on_move=self.on_move, on_click=self.on_click, on_scroll=self.on_scroll
         )
         self._listener.start()
+
+    def stop(self):
+        if self._listener is not None:
+            self._listener.stop()
 
     def is_alive(self) -> bool:
         return self._listener is not None and self._listener.is_alive()

--- a/aw_watcher_afk/unix.py
+++ b/aw_watcher_afk/unix.py
@@ -10,17 +10,37 @@ class LastInputUnix:
         self.logger = logging.getLogger(__name__)
         # self.logger.setLevel(logging.DEBUG)
 
+        self._start_listeners()
+        self.last_activity = datetime.now()
+
+    def _start_listeners(self):
         self.mouseListener = MouseListener()
         self.mouseListener.start()
 
         self.keyboardListener = KeyboardListener()
         self.keyboardListener.start()
 
-        self.last_activity = datetime.now()
+    def _check_listeners(self):
+        """Check if input listeners are still alive, restart if dead.
+
+        Pynput listeners can silently die when the X server restarts
+        (e.g. after suspend/resume, display server crash, or session switch).
+        Without this check, the watcher would permanently report AFK.
+
+        See: https://github.com/ActivityWatch/aw-watcher-afk/issues/27
+        """
+        if not self.mouseListener.is_alive() or not self.keyboardListener.is_alive():
+            self.logger.warning(
+                "Input listeners died (X server restart?), reinitializing..."
+            )
+            self._start_listeners()
+            # Reset last_activity so we don't report a huge AFK gap
+            self.last_activity = datetime.now()
 
     def seconds_since_last_input(self) -> float:
         # TODO: This has a delay of however often it is called.
         #       Could be solved by creating a custom listener.
+        self._check_listeners()
         now = datetime.now()
         if self.mouseListener.has_new_event() or self.keyboardListener.has_new_event():
             self.logger.debug("New event")

--- a/aw_watcher_afk/unix.py
+++ b/aw_watcher_afk/unix.py
@@ -20,6 +20,13 @@ class LastInputUnix:
         self.keyboardListener = KeyboardListener()
         self.keyboardListener.start()
 
+    def _stop_listeners(self):
+        """Stop existing listeners to avoid duplicate instances."""
+        if self.mouseListener.is_alive():
+            self.mouseListener.stop()
+        if self.keyboardListener.is_alive():
+            self.keyboardListener.stop()
+
     def _check_listeners(self):
         """Check if input listeners are still alive, restart if dead.
 
@@ -33,6 +40,9 @@ class LastInputUnix:
             self.logger.warning(
                 "Input listeners died (X server restart?), reinitializing..."
             )
+            # Stop any still-running listeners before creating new ones
+            # to avoid duplicate listener instances (e.g. if only one died)
+            self._stop_listeners()
             self._start_listeners()
             # Reset last_activity so we don't report a huge AFK gap
             self.last_activity = datetime.now()

--- a/tests/test_listener_health.py
+++ b/tests/test_listener_health.py
@@ -1,0 +1,81 @@
+"""Tests for listener health checking and auto-recovery."""
+
+import threading
+from unittest.mock import MagicMock, patch
+
+from aw_watcher_afk.listeners import KeyboardListener, MouseListener
+
+
+def test_keyboard_listener_is_alive_before_start():
+    listener = KeyboardListener()
+    assert not listener.is_alive()
+
+
+def test_mouse_listener_is_alive_before_start():
+    listener = MouseListener()
+    assert not listener.is_alive()
+
+
+def test_keyboard_listener_is_alive_with_mock():
+    listener = KeyboardListener()
+    # Simulate a started listener
+    mock_pynput = MagicMock()
+    mock_pynput.is_alive.return_value = True
+    listener._listener = mock_pynput
+    assert listener.is_alive()
+
+
+def test_keyboard_listener_dead_after_x_restart():
+    listener = KeyboardListener()
+    # Simulate a dead listener (X server died)
+    mock_pynput = MagicMock()
+    mock_pynput.is_alive.return_value = False
+    listener._listener = mock_pynput
+    assert not listener.is_alive()
+
+
+def test_mouse_listener_is_alive_with_mock():
+    listener = MouseListener()
+    mock_pynput = MagicMock()
+    mock_pynput.is_alive.return_value = True
+    listener._listener = mock_pynput
+    assert listener.is_alive()
+
+
+def test_mouse_listener_dead_after_x_restart():
+    listener = MouseListener()
+    mock_pynput = MagicMock()
+    mock_pynput.is_alive.return_value = False
+    listener._listener = mock_pynput
+    assert not listener.is_alive()
+
+
+@patch("aw_watcher_afk.unix.KeyboardListener")
+@patch("aw_watcher_afk.unix.MouseListener")
+def test_unix_reinitializes_dead_listeners(MockMouse, MockKeyboard):
+    """When listeners die (e.g. X server restart), they should be restarted."""
+    from aw_watcher_afk.unix import LastInputUnix
+
+    # First call: listeners are alive
+    mock_kb_instance = MockKeyboard.return_value
+    mock_mouse_instance = MockMouse.return_value
+    mock_kb_instance.is_alive.return_value = True
+    mock_mouse_instance.is_alive.return_value = True
+    mock_kb_instance.has_new_event.return_value = False
+    mock_mouse_instance.has_new_event.return_value = False
+
+    unix = LastInputUnix()
+    unix.seconds_since_last_input()
+
+    # Listeners should NOT have been restarted
+    assert MockKeyboard.call_count == 1
+    assert MockMouse.call_count == 1
+
+    # Now simulate X server death
+    mock_kb_instance.is_alive.return_value = False
+
+    unix.seconds_since_last_input()
+
+    # Listeners should have been restarted (new instances created)
+    assert MockKeyboard.call_count == 2
+    assert MockMouse.call_count == 2

--- a/tests/test_listener_health.py
+++ b/tests/test_listener_health.py
@@ -1,6 +1,5 @@
 """Tests for listener health checking and auto-recovery."""
 
-import threading
 from unittest.mock import MagicMock, patch
 
 from aw_watcher_afk.listeners import KeyboardListener, MouseListener


### PR DESCRIPTION
## Summary

- Add `is_alive()` method to `KeyboardListener` and `MouseListener` that checks if the underlying pynput listener thread is still running
- Add health checking in `LastInputUnix.seconds_since_last_input()` — on every poll cycle, checks if listeners are alive and reinitializes them if dead
- Reset `last_activity` timestamp on reinitialization to prevent reporting a spurious AFK gap

## Problem

When the X server restarts (suspend/resume, display server crash, session switch), pynput listener threads silently die — they stop receiving events but don't raise any errors. The watcher then permanently reports AFK because `has_new_event()` always returns `False`.

This is a long-standing issue reported in #27 (2017).

## Test plan

- [x] 7 unit tests added covering:
  - `is_alive()` returns `False` before `start()` is called
  - `is_alive()` correctly reflects underlying pynput thread state
  - `LastInputUnix` detects dead listeners and reinitializes them
  - Reinitialization creates fresh listener instances
- [ ] Manual testing: kill X server while watcher is running, verify it auto-recovers

Fixes #27
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes issue where input listeners die after X server restart by adding health checks and auto-recovery.
> 
>   - **Behavior**:
>     - Adds `is_alive()` to `KeyboardListener` and `MouseListener` to check if pynput listener threads are running.
>     - In `LastInputUnix.seconds_since_last_input()`, checks listener health and reinitializes if dead.
>     - Resets `last_activity` timestamp on reinitialization to avoid false AFK reporting.
>   - **Tests**:
>     - Adds `test_listener_health.py` with tests for `is_alive()` behavior and listener reinitialization.
>     - Tests cover scenarios before and after listener start, and after X server restart.
>   - **Misc**:
>     - Addresses issue #27 by ensuring listeners auto-recover after X server restarts.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Faw-watcher-afk&utm_source=github&utm_medium=referral)<sup> for 984a2ae0464d662470a813c7365ae949cf54ae39. You can [customize](https://app.ellipsis.dev/ActivityWatch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->