### PR TITLE
fix: address Greptile P2s from #82 — partial gamepad death + ambiguous log

### DIFF
--- a/aw_watcher_afk/listeners.py
+++ b/aw_watcher_afk/listeners.py
@@ -209,15 +209,22 @@ class GamepadListener(EventFactory):
         return any(t.is_alive() for t in self._threads)
 
     def needs_restart(self) -> bool:
-        """Return True if start() previously launched threads but they have all died.
+        """Return True if start() previously launched threads but any have died.
 
         Used to distinguish a system that simply has no gamepad attached (in
         which case start() returned early and no restart is needed) from one
-        where all reader threads have exited unexpectedly (e.g. device removed
-        or USB error). In the latter case the caller should reinitialize the
-        listener so a reconnected gamepad starts being tracked again.
+        where one or more reader threads have exited unexpectedly (e.g. device
+        removed or USB error). In the latter case the caller should reinitialize
+        the listener so all gamepads start being tracked again.
+
+        Detects partial failure (one of N gamepads removed) in addition to
+        total failure (all gamepads removed), so multi-gamepad setups don't
+        silently lose a device until the last one dies.
         """
-        return self._was_started and not self.is_alive()
+        if not self._was_started:
+            return False
+        # Restart when any reader thread has died, not just when all have.
+        return any(not t.is_alive() for t in self._threads)
 
     # ------------------------------------------------------------------
     # Internals

--- a/aw_watcher_afk/unix.py
+++ b/aw_watcher_afk/unix.py
@@ -53,7 +53,15 @@ class LastInputUnix:
             or not self.keyboardListener.is_alive()
             or gamepad_died
         ):
-            if gamepad_died:
+            mouse_kb_died = (
+                not self.mouseListener.is_alive()
+                or not self.keyboardListener.is_alive()
+            )
+            if gamepad_died and mouse_kb_died:
+                self.logger.warning(
+                    "All input listeners died (X server restart?), reinitializing..."
+                )
+            elif gamepad_died:
                 self.logger.warning(
                     "Gamepad listener died (device removed?), reinitializing..."
                 )

--- a/tests/test_listener_health.py
+++ b/tests/test_listener_health.py
@@ -303,3 +303,85 @@ def test_unix_restarts_when_only_gamepad_dies(MockGamepad, MockMouse, MockKeyboa
     assert MockKeyboard.call_count == 2
     assert MockMouse.call_count == 2
     assert MockGamepad.call_count == 2
+
+
+def test_gamepad_needs_restart_true_when_one_of_two_threads_dies():
+    """needs_restart() must be True if any thread dies, not only when all die.
+
+    This covers multi-gamepad setups where one device is removed while another
+    stays alive; without this the dead device goes silently unmonitored.
+
+    Uses direct thread-state injection to avoid mock-revert races with
+    background threads (see lessons/tools/mock-revert-race-background-threads.md).
+    """
+    import threading
+
+    listener = GamepadListener()
+    listener._was_started = True
+
+    # dead_thread: simulates a gamepad that was unplugged (thread exited)
+    dead_thread = threading.Thread(target=lambda: None, daemon=True)
+    dead_thread.start()
+    dead_thread.join(timeout=2.0)
+    assert not dead_thread.is_alive()
+
+    # live_thread: simulates a gamepad still connected (thread still running)
+    keep_alive = threading.Event()
+    live_thread = threading.Thread(target=keep_alive.wait, daemon=True)
+    live_thread.start()
+
+    listener._threads = [dead_thread, live_thread]
+
+    try:
+        # is_alive() should see the live thread; needs_restart() should fire on the dead one
+        assert listener.is_alive()
+        assert listener.needs_restart()
+    finally:
+        keep_alive.set()
+        live_thread.join(timeout=2.0)
+
+
+@patch("aw_watcher_afk.unix.KeyboardListener")
+@patch("aw_watcher_afk.unix.MouseListener")
+@patch("aw_watcher_afk.unix.GamepadListener")
+def test_unix_log_message_when_gamepad_and_keyboard_die_together(
+    MockGamepad, MockMouse, MockKeyboard, caplog
+):
+    """When gamepad AND mouse/keyboard die simultaneously, the log should say
+    'All input listeners died' (XServer restart context), not just 'Gamepad
+    listener died' (device-removal context).
+    """
+    import logging
+    from aw_watcher_afk.unix import LastInputUnix
+
+    mock_kb = MockKeyboard.return_value
+    mock_mouse = MockMouse.return_value
+    mock_gamepad = MockGamepad.return_value
+
+    mock_kb.is_alive.return_value = True
+    mock_mouse.is_alive.return_value = True
+    mock_gamepad.is_alive.return_value = True
+    mock_gamepad.needs_restart.return_value = False
+    mock_kb.has_new_event.return_value = False
+    mock_mouse.has_new_event.return_value = False
+    mock_gamepad.has_new_event.return_value = False
+
+    unix = LastInputUnix()
+    unix.seconds_since_last_input()
+
+    # Simulate all listeners dying at once (XServer crash)
+    mock_kb.is_alive.return_value = False
+    mock_mouse.is_alive.return_value = False
+    mock_gamepad.is_alive.return_value = False
+    mock_gamepad.needs_restart.return_value = True
+
+    with caplog.at_level(logging.WARNING):
+        unix.seconds_since_last_input()
+
+    warning_messages = [r.message for r in caplog.records if r.levelno == logging.WARNING]
+    assert any("All input listeners died" in m for m in warning_messages), (
+        f"Expected 'All input listeners died' in log, got: {warning_messages}"
+    )
+    assert not any("Gamepad listener died" in m for m in warning_messages), (
+        f"Should not say 'Gamepad listener died' when all died: {warning_messages}"
+    )


### PR DESCRIPTION
Follow-up to #82 as requested by @ErikBjare. Addresses the two P2 items flagged by Greptile.

## Changes

### P2 — Multi-gamepad partial device loss (silent)

`needs_restart()` previously returned `True` only when **all** reader threads died. On a system with two gamepads, unplugging one left its device silently unmonitored until the second also died.

Fix: check `any(not t.is_alive() for t in self._threads)` instead of `not self.is_alive()`. The `_was_started` guard still prevents false restarts on gamepad-less systems.

### P2 — Ambiguous log message on simultaneous multi-listener death

When all listeners (gamepad + keyboard/mouse) died at once (e.g. XServer restart), `_check_listeners()` logged `"Gamepad listener died (device removed?)"` — pointing at the wrong cause. The fix adds a `mouse_kb_died` check and logs `"All input listeners died (X server restart?)"` when the full set is down.

## Tests

Two new tests in `test_listener_health.py` (20 total, all green):

- `test_gamepad_needs_restart_true_when_one_of_two_threads_dies` — injects thread state directly (avoids mock-revert races with background threads) to verify partial death triggers `needs_restart()`.
- `test_unix_log_message_when_gamepad_and_keyboard_die_together` — uses `caplog` to assert the correct disambiguation message fires when all listeners die together.