### PR TITLE
fix(windows): retry failed idle queries safely

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ build:
 
 test:
 	poetry run aw-watcher-afk --help  # Ensures that it at least starts
+	poetry run python -m unittest discover -s tests -p "test_afk_failures.py"
 	make typecheck
 
 typecheck:

--- a/aw_watcher_afk/afk.py
+++ b/aw_watcher_afk/afk.py
@@ -88,7 +88,9 @@ class AFKWatcher:
                 now = datetime.now(timezone.utc)
                 try:
                     seconds_since_input = seconds_since_last_input()
-                except Exception:
+                except OSError:
+                    if system != "Windows":
+                        raise
                     logger.exception(
                         "seconds_since_last_input() failed; "
                         "retrying without changing AFK state"

--- a/aw_watcher_afk/afk.py
+++ b/aw_watcher_afk/afk.py
@@ -86,7 +86,15 @@ class AFKWatcher:
                     break
 
                 now = datetime.now(timezone.utc)
-                seconds_since_input = seconds_since_last_input()
+                try:
+                    seconds_since_input = seconds_since_last_input()
+                except Exception:
+                    logger.exception(
+                        "seconds_since_last_input() failed; "
+                        "retrying without changing AFK state"
+                    )
+                    sleep(self.settings.poll_time)
+                    continue
                 last_input = now - timedelta(seconds=seconds_since_input)
                 logger.debug(f"Seconds since last input: {seconds_since_input}")
 

--- a/aw_watcher_afk/windows.py
+++ b/aw_watcher_afk/windows.py
@@ -1,6 +1,6 @@
 import ctypes
 import time
-from ctypes import POINTER, WINFUNCTYPE, Structure, c_ulonglong  # type: ignore
+from ctypes import POINTER, Structure, c_ulonglong
 from ctypes.wintypes import BOOL, DWORD, UINT
 
 ULONGLONG = c_ulonglong
@@ -11,25 +11,26 @@ class LastInputInfo(Structure):
 
 
 def _getLastInputTick() -> int:
-    prototype = WINFUNCTYPE(BOOL, POINTER(LastInputInfo))
+    prototype = ctypes.WINFUNCTYPE(BOOL, POINTER(LastInputInfo))  # type: ignore[attr-defined]
     paramflags = ((1, "lastinputinfo"),)
     c_GetLastInputInfo = prototype(("GetLastInputInfo", ctypes.windll.user32), paramflags)  # type: ignore
 
     lastinput = LastInputInfo()
     lastinput.cbSize = ctypes.sizeof(LastInputInfo)
-    assert 0 != c_GetLastInputInfo(lastinput)
+    if 0 == c_GetLastInputInfo(lastinput):
+        raise OSError("GetLastInputInfo failed")
     return lastinput.dwTime
 
 
 def _getTickCount64() -> int:
     """Use GetTickCount64 to avoid 32-bit overflow after ~49.7 days of uptime."""
-    prototype = WINFUNCTYPE(ULONGLONG)
+    prototype = ctypes.WINFUNCTYPE(ULONGLONG)  # type: ignore[attr-defined]
     paramflags = ()
     c_GetTickCount64 = prototype(("GetTickCount64", ctypes.windll.kernel32), paramflags)  # type: ignore
     return c_GetTickCount64()
 
 
-def seconds_since_last_input():
+def seconds_since_last_input() -> float:
     tick_count = _getTickCount64()
     last_input_tick = _getLastInputTick()  # 32-bit DWORD from GetLastInputInfo
 

--- a/tests/test_afk_failures.py
+++ b/tests/test_afk_failures.py
@@ -1,0 +1,76 @@
+import os
+import unittest
+from contextlib import ExitStack
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from aw_watcher_afk import windows
+from aw_watcher_afk.afk import AFKWatcher
+
+
+class WindowsIdleQueryTests(unittest.TestCase):
+    def test_get_last_input_failure_raises(self):
+        with patch.object(
+            windows.ctypes, "WINFUNCTYPE", create=True
+        ) as prototype_factory:
+            with patch.object(windows.ctypes, "windll", create=True):
+                prototype_factory.return_value.return_value.return_value = 0
+
+                with self.assertRaisesRegex(OSError, "GetLastInputInfo failed"):
+                    windows._getLastInputTick()
+
+
+class HeartbeatFailureTests(unittest.TestCase):
+    def make_watcher(self):
+        watcher = object.__new__(AFKWatcher)
+        watcher.settings = SimpleNamespace(timeout=10, poll_time=5)
+        watcher._initial_ppid = os.getppid()
+        return watcher
+
+    def run_loop(self, watcher, samples):
+        with ExitStack() as stack:
+            stack.enter_context(patch("aw_watcher_afk.afk.system", "Windows"))
+            stack.enter_context(
+                patch(
+                    "aw_watcher_afk.afk.seconds_since_last_input",
+                    side_effect=samples,
+                )
+            )
+            ping = stack.enter_context(patch.object(watcher, "ping"))
+            sleep = stack.enter_context(patch("aw_watcher_afk.afk.sleep"))
+            log_exception = stack.enter_context(
+                patch("aw_watcher_afk.afk.logger.exception")
+            )
+            watcher.heartbeat_loop()
+        return ping, sleep, log_exception
+
+    def test_failed_sample_preserves_afk_state_and_recovers(self):
+        watcher = self.make_watcher()
+        samples = [20.0, OSError("idle API unavailable"), 20.0, KeyboardInterrupt()]
+
+        ping, sleep, log_exception = self.run_loop(watcher, samples)
+
+        self.assertEqual(
+            [record.args[0] for record in ping.call_args_list],
+            [False, True, True],
+        )
+        self.assertEqual(sleep.call_count, 3)
+        self.assertEqual(log_exception.call_count, 1)
+
+    def test_repeated_failures_sleep_without_emitting_heartbeats(self):
+        watcher = self.make_watcher()
+        samples = [
+            OSError("idle API unavailable"),
+            OSError("idle API unavailable"),
+            KeyboardInterrupt(),
+        ]
+
+        ping, sleep, log_exception = self.run_loop(watcher, samples)
+
+        ping.assert_not_called()
+        self.assertEqual(sleep.call_count, 2)
+        self.assertEqual(log_exception.call_count, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_afk_failures.py
+++ b/tests/test_afk_failures.py
@@ -27,9 +27,9 @@ class HeartbeatFailureTests(unittest.TestCase):
         watcher._initial_ppid = os.getppid()
         return watcher
 
-    def run_loop(self, watcher, samples):
+    def run_loop(self, watcher, samples, system_name="Windows"):
         with ExitStack() as stack:
-            stack.enter_context(patch("aw_watcher_afk.afk.system", "Windows"))
+            stack.enter_context(patch("aw_watcher_afk.afk.system", system_name))
             stack.enter_context(
                 patch(
                     "aw_watcher_afk.afk.seconds_since_last_input",
@@ -70,6 +70,12 @@ class HeartbeatFailureTests(unittest.TestCase):
         ping.assert_not_called()
         self.assertEqual(sleep.call_count, 2)
         self.assertEqual(log_exception.call_count, 2)
+
+    def test_non_windows_failure_reaches_supervisor(self):
+        watcher = self.make_watcher()
+
+        with self.assertRaisesRegex(OSError, "listener failed"):
+            self.run_loop(watcher, [OSError("listener failed")], system_name="Linux")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- replace the `GetLastInputInfo` assertion with an explicit failure
- wait one poll interval and retry a failed idle sample without emitting a heartbeat or changing AFK state
- add regression coverage for failure, recovery, and persistent-failure pacing

## Why

A transient platform idle-query failure currently terminates the watcher. Treating the failure as zero seconds idle would be worse: it fabricates activity and can end a genuine AFK interval. This preserves the last known state until a valid sample arrives.

Related: ActivityWatch/activitywatch#1312. That report does not establish this failure path, so this PR does not claim to resolve it.

## Test plan

- `make test`
- `poetry run python -m py_compile aw_watcher_afk/afk.py aw_watcher_afk/windows.py tests/test_afk_failures.py`
- `git diff --check origin/master...HEAD`